### PR TITLE
refactor: update texture_size cut to support larger texture_size

### DIFF
--- a/packages/paddlejs-backend-webgl/src/ops/atom/suffix.ts
+++ b/packages/paddlejs-backend-webgl/src/ops/atom/suffix.ts
@@ -2,6 +2,9 @@
  * @file suffix code obtaining output position
  */
 
+
+import { GLHelper } from '../../webgl/WebGLUtils';
+
 interface OutParams {
     height_shape: number;
     width_shape: number;
@@ -27,16 +30,17 @@ function getOutputTensorPos({ height_shape, channel }: OutParams): string {
 function getOutputTensorPosLimit({ height_shape, width_shape, channel }: OutParams): string {
     return `
     ivec4 getOutputTensorPos() {
+        float limitCut = float(${GLHelper.getWebglTextureLimitCut()});
         // 获取原始长度
         vec2 outCoord = vCoord.xy * _2d_shape_texture_out;
         float offsetY = floor(outCoord.y / float(${height_shape}));
         int x = int(outCoord.x / float(${channel}));
-        if (mod(offsetY, 4.0) > 0.0) {
-            x += calMod(int(offsetY), 4) * int(ceil(float(${width_shape}) / 4.0));
+        if (mod(offsetY, limitCut) > 0.0) {
+            x += calMod(int(offsetY), int(limitCut)) * int(ceil(float(${width_shape}) / limitCut));
         }
         int y = calMod(int(outCoord.y), ${height_shape});
         int c = calMod(int(outCoord.x), ${channel});
-        int b = int(outCoord.y / float(4 * ${height_shape}));
+        int b = int(outCoord.y / float(int(limitCut) * ${height_shape}));
         return ivec4(b, c, y, x);
     }
     `;

--- a/packages/paddlejs-backend-webgl/src/ops/index.ts
+++ b/packages/paddlejs-backend-webgl/src/ops/index.ts
@@ -15,6 +15,7 @@ import pool2d_winograd from './shader/pool2d_winograd';
 import elementwise_add from './shader/elementwise_add';
 import mul from './shader/mul';
 import matmul from './shader/matmul';
+import matmul_v2 from './shader/matmul_v2';
 import fc from './shader/fc';
 import dropout from './shader/dropout';
 import concat from './shader/concat';
@@ -81,6 +82,7 @@ const ops = {
     elementwise_sub,
     mul,
     matmul,
+    matmul_v2,
     fc,
     dropout,
     concat,

--- a/packages/paddlejs-backend-webgl/src/ops/shader/matmul.ts
+++ b/packages/paddlejs-backend-webgl/src/ops/shader/matmul.ts
@@ -6,10 +6,14 @@ function mainFunc(
     { origin },
     {
         transpose_X = false,
-        transpose_Y = false
+        transpose_Y = false,
+        trans_x = false,
+        trans_y = false
     }
 ) {
-    const sharedDim = transpose_X ? origin.height_shape : origin.width_shape;
+    const tX = transpose_X || trans_x;
+    const tY = transpose_Y || trans_y;
+    const sharedDim = tX ? origin.height_shape : origin.width_shape;
 
     return `
     void main() {
@@ -17,22 +21,22 @@ function mainFunc(
         // 获取output的坐标
         ivec4 out_pos = getOutputTensorPos();
         ivec4 origin_pos = out_pos;
-        if (${transpose_X}) {
+        if (${tX}) {
             origin_pos[3] = origin_pos[2];
         }
         ivec4 counter_pos = out_pos;
-        if (${transpose_Y}) {
+        if (${tY}) {
             counter_pos[2] = counter_pos[3];
         }
 
         for (int j = 0; j < ${sharedDim}; j++) {
-            if (${transpose_X}) {
+            if (${tX}) {
                 origin_pos[2] = j;
             }
             else {
                 origin_pos[3] = j;
             }
-            if (${transpose_Y}) {
+            if (${tY}) {
                 counter_pos[3] = j;
             }
             else {
@@ -51,7 +55,9 @@ export default {
     mainFunc,
     params: [
         'transpose_X',
-        'transpose_Y'
+        'transpose_Y',
+        'trans_x',
+        'trans_y'
     ],
     textureFuncConf: {
         counter: ['getValueFromTensorPos'],

--- a/packages/paddlejs-backend-webgl/src/ops/shader/matmul_v2.ts
+++ b/packages/paddlejs-backend-webgl/src/ops/shader/matmul_v2.ts
@@ -1,0 +1,7 @@
+/**
+ * @file matmul_v2
+ */
+
+import matmul from './matmul';
+
+export default matmul;

--- a/packages/paddlejs-backend-webgl/src/ops/utils.ts
+++ b/packages/paddlejs-backend-webgl/src/ops/utils.ts
@@ -9,7 +9,7 @@ interface opInfo {
     [key: string]: any
 }
 
-const inputParams = [
+const tensorParams = [
     'length_shape',
     'length_unformatted_shape',
     'width_shape',
@@ -24,15 +24,6 @@ const inputParams = [
     'numbers_shape'
 ];
 
-const outParams = [
-    'total_shape',
-    'width_shape',
-    'height_shape',
-    'width_texture',
-    'height_texture',
-    'channel',
-    'limit'
-];
 
 const baseParams = {
     float: [
@@ -44,23 +35,22 @@ const baseParams = {
     ]
 };
 
-function getTensorParams(inputTensors: Tensor[], ownParams: [], fShaderParams: object, runtime: number): opInfo {
+function getTensorParams(tensors: Tensor[], ownParams: [], fShaderParams: object, runtime: number): opInfo {
     const tensorsParams = {};
     const opParams = {};
     const tensorNames = [] as string[];
-
-    // inputParams
-    for (const tensor of inputTensors) {
+    // tensorParams
+    for (const tensor of tensors) {
         const name = tensor.name;
         // 提取inputParams
-        const inputVars = {};
-        for (const param of inputParams) {
+        const tensorVars = {};
+        for (const param of tensorParams) {
             if (typeof (tensor[param]) !== 'undefined') {
-                inputVars[param] = tensor[param];
+                tensorVars[param] = tensor[param];
             }
         }
 
-        tensorsParams[name] = inputVars;
+        tensorsParams[name] = tensorVars;
         tensorNames.push(name);
     }
 
@@ -83,15 +73,6 @@ function getTensorParams(inputTensors: Tensor[], ownParams: [], fShaderParams: o
             }
         }
     }
-
-    // outputParams
-    const outputVars = {};
-    for (const param of outParams) {
-        if (typeof (fShaderParams[param + '_out']) !== 'undefined') {
-            outputVars[param] = fShaderParams[param + '_out'];
-        }
-    }
-    tensorsParams['out'] = outputVars;
 
     // 将active_function放在opParams中
     if (fShaderParams['active_function']) {

--- a/packages/paddlejs-backend-webgl/src/webgl/WebGLUtils.ts
+++ b/packages/paddlejs-backend-webgl/src/webgl/WebGLUtils.ts
@@ -3,9 +3,10 @@
  * @author yueshuangyan
  */
 
+import { Tensor } from '../types';
 import { env } from '@paddlejs/paddlejs-core';
 import { WebGLContextAttributes, UniformType } from './webgl_types';
-import { Tensor } from '../types';
+
 
 // 枚举类
 export enum EShaderType
@@ -82,6 +83,10 @@ export class GLHelper {
 
     public static getWebglVersion() {
         return env.get('webglVersion');
+    }
+
+    public static getWebglTextureLimitCut() {
+        return 8;
     }
 
     public static createCanvas() {
@@ -415,10 +420,10 @@ export class GLHelper {
         let exceedMax = false;
         // trick TEXTURE_SIZE 超限问题，后续升级更优解
         if (height > GL_TEXTURE_MAX_SIZE || width > GL_TEXTURE_MAX_SIZE) {
-            console.error('大小超限', shape);
-            height *= 8;
-            width = c * (Math.ceil(w / 8));
-            console.log(`[${width}x${height}]`);
+            const textureCut = this.getWebglTextureLimitCut();
+            env.get('debug') && console.error('大小超限', shape);
+            height *= textureCut;
+            width = c * (Math.ceil(w / textureCut));
             exceedMax = true;
             if (height > GL_TEXTURE_MAX_SIZE || width > GL_TEXTURE_MAX_SIZE) {
                 const requested = `[${width}x${height}]`;
@@ -429,7 +434,7 @@ export class GLHelper {
             }
         }
 
-        tensor.shape_texture = [4, height, width];
+        tensor.shape_texture = [height, width];
         tensor.exceedMax = exceedMax;
     }
 

--- a/packages/paddlejs-backend-webgl/src/webgl/buildShader.ts
+++ b/packages/paddlejs-backend-webgl/src/webgl/buildShader.ts
@@ -10,14 +10,13 @@ import genSuffixCode from '../ops/atom/suffix';
 import * as commonFunc from '../ops/atom/common_func';
 import * as textureFunc from '../ops/atom/common_func_with_texture';
 
-export default function buildShader(textureConf, op, inputTensors, fShaderParams, runtime: number) {
+export default function buildShader(textureConf, op, tensors, fShaderParams, runtime: number) {
     let code = '';
     const { name, params = {}, mainFunc, textureFuncConf = {}, commonFuncConf } = op;
-
     try {
         // textureList: [filter, origin, bias]
         const { textureParams, opParams, active_function } = getTensorParams(
-            inputTensors, params, fShaderParams, runtime
+            tensors, params, fShaderParams, runtime
         );
 
         const prefixCode = genPrefixCode(textureConf);

--- a/packages/paddlejs-core/src/opFactory/opDataBuilder.ts
+++ b/packages/paddlejs-core/src/opFactory/opDataBuilder.ts
@@ -253,19 +253,6 @@ export default class OpData {
     }
 
     buildShaderParams() {
-        // 从tensor对象中获取的数据
-        const tensorAttrs = [
-            'length_shape',
-            'length_unformatted_shape',
-            'width_shape',
-            'height_shape',
-            'width_texture',
-            'height_texture',
-            'limit',
-            'channel',
-            'total_shape',
-            'binding'
-        ];
 
         for (const key in this.attrs) {
             if (Object.prototype.hasOwnProperty.call(this.attrs, key)) {
@@ -273,21 +260,10 @@ export default class OpData {
                 this.data[key] = item;
             }
         }
-        // 遍历 获取input tensor的数据
-        this.inputTensors.forEach((inputTensor: Tensor) => {
-            tensorAttrs.forEach(attr => {
-                this.data[attr + '_' + inputTensor.name] = inputTensor[attr];
-            });
-        });
 
         // 根据out tensor 个数 生成对应的 fShader 个数
-        this.outputTensors.forEach((outTensor: Tensor) => {
+        this.outputTensors.forEach(() => {
             const params = JSON.parse(JSON.stringify(this.data));
-            // 获取output tensor的数据
-
-            tensorAttrs.forEach(attr => {
-                params[attr + '_' + outTensor.name] = outTensor[attr];
-            });
             this.fShaderParams.push(params);
         });
     }

--- a/packages/paddlejs-core/src/opFactory/tensor.ts
+++ b/packages/paddlejs-core/src/opFactory/tensor.ts
@@ -56,13 +56,7 @@ export default class Tensor {
         if (opts.noLayout) {
             return;
         }
-        // 获取转换到texture后的信息
-        const {
-            exceedMax,
-            shape: shape_texture
-        } = Utils.getTextureInfoFromTensorShape(shape, opts.isPacked);
-        this.shape_texture = shape_texture;
-        this.exceedMax = exceedMax;
+
         // tensor数据
         if (opts.data && opts.data.length) {
             this.data = Utils.genTensorData(opts.data, this.dataLayout, shape, this.isPacked);
@@ -72,12 +66,12 @@ export default class Tensor {
 
     get width_texture() {
         const length = this.shape_texture.length;
-        return this.shape_texture[length - 1];
+        return this.shape_texture[length - 1] || 1;
     }
 
     get height_texture() {
         const length = this.shape_texture.length;
-        return this.shape_texture[length - 2];
+        return this.shape_texture[length - 2] || 1;
     }
 
     get width_shape() {


### PR DESCRIPTION
1. 从 core 迁移 texture size 裁剪至 webgl；webgpu limit size 和 webgl 不一样，超限支持单独写
2. 重构 裁剪功能，优化写法，收敛分片常量定义
3. 目前方案已支持 (16384, 16384 * 32) size，完美支持 ocr
4. todo：支持根据 logical shape 动态选择最佳裁剪方案