### PR TITLE
feat(texture): reallocate texture shape

### DIFF
--- a/packages/paddlejs-backend-webgl/src/ops/shader/custom/pack_out.ts
+++ b/packages/paddlejs-backend-webgl/src/ops/shader/custom/pack_out.ts
@@ -3,50 +3,31 @@
  */
 
 function mainFunc(
-    { origin },
+    { out },
     {}
 ) {
-    const width_texture_origin = origin.width_texture;
-    const height_texture_origin = origin.height_texture;
     return `
-
-    vec2 getOriginCoord(float x, float y) {
-        if (x > float(${width_texture_origin})) {
-            int num = int(x / float(${width_texture_origin}));
-            x = mod(x, float(${width_texture_origin}));
-            y = y + float(num);
-        }
-        return vec2(x, y);
-    }
-
-    float getClipedCoordRed(vec2 xy) {
-        return TEXTURE2D(
-            texture_origin,
-            vec2(float(xy.x / float(${width_texture_origin})), float(xy.y / float(${height_texture_origin})))
-        ).r;
-    }
 
     // start函数
     void main() {
-        
+        ivec4 oPos = getOutputTensorPos();
         vec2 outCoord = vCoord.xy * _2d_shape_texture_out;
-        vec4 out4;
-        float x = floor(outCoord.x) * 4.0;
-        float y = floor(outCoord.y) * 4.0 + 0.5;
-        float x0 = x + 0.5;
-        float x1 = x + 1.5;
-        float x2 = x + 2.5;
-        float x3 = x + 3.5;
+        int index = int(outCoord.x) + int(outCoord.y) * int(${out.width_texture});
 
-        vec2 xy0 = getOriginCoord(x0, y);
-        vec2 xy1 = getOriginCoord(x1, y);
-        vec2 xy2 = getOriginCoord(x2, y);
-        vec2 xy3 = getOriginCoord(x3, y);
+        int first = index * 4;
+        int sec = index * 4 + 1;
+        int third = index * 4 + 2;
+        int fourth = index * 4 + 3;
 
-        float r = getClipedCoordRed(xy0);
-        float g = getClipedCoordRed(xy1);
-        float b = getClipedCoordRed(xy2);
-        float a = getClipedCoordRed(xy3);
+        ivec4 rPos = getTensorPosFromArrayIndex_origin(first);
+        ivec4 gPos = getTensorPosFromArrayIndex_origin(sec);
+        ivec4 bPos = getTensorPosFromArrayIndex_origin(third);
+        ivec4 aPos = getTensorPosFromArrayIndex_origin(fourth);
+
+        float r = getValueFromTensorPos_origin(rPos.r, rPos.g, rPos.b, rPos.a);
+        float g = getValueFromTensorPos_origin(gPos.r, gPos.g, gPos.b, gPos.a);
+        float b = getValueFromTensorPos_origin(bPos.r, bPos.g, bPos.b, bPos.a);
+        float a = getValueFromTensorPos_origin(aPos.r, aPos.g, aPos.b, aPos.a);
 
         setPackedOutput(vec4(r, g, b, a));
     }
@@ -55,6 +36,6 @@ function mainFunc(
 export default {
     mainFunc,
     textureFuncConf: {
-        origin: ['getValueFromTensorPosPacking', 'getValueFromTensorPos']
+        origin: ['getValueFromTensorPos', 'getTensorPosFromArrayIndex']
     }
 };

--- a/packages/paddlejs-backend-webgl/src/utils/dataProcess.ts
+++ b/packages/paddlejs-backend-webgl/src/utils/dataProcess.ts
@@ -81,11 +81,26 @@ function genIntDataCode(dataArr: number[], key) {
     return dataStr;
 }
 
+function getSmallestDivisor(number, base) {
+    let divisor = base;
+    if (number % divisor === 0) {
+        return divisor;
+    }
+    while (divisor < number) {
+        if (number % divisor === 0) {
+            break;
+        }
+        divisor++;
+    }
+    return divisor;
+}
+
 export {
     nhwc2nchw,
     getSizeFromShape,
     reduceShape,
     genFpDataCode,
     genFpFloatArr,
-    genIntDataCode
+    genIntDataCode,
+    getSmallestDivisor
 };


### PR DESCRIPTION
1. 升级 texture  shape 分配，解耦 与 tensor shape 关系
<img width="747" alt="image" src="https://user-images.githubusercontent.com/10822846/153136353-515a9ab0-d3ca-4481-bea4-1ef7bd9b9c36.png">
从之前 (nh, cw) 变更为 [smallest * biggest, sec*third]

收益：
ocr 模型texture 超限，从 475 个 texture 超限（大量 算子 shape [1, 80, 1, 256] 和 [1, 512, 2, 160]） 降为 8 个 

2. 超限处理
<img width="631" alt="image" src="https://user-images.githubusercontent.com/10822846/153136484-dfb3b724-3e32-4252-9482-20625c145615.png">
寻找大边 bigger 能够正处的最小除数，且除与最小除数后小于 GL_TEXTURE_MAX_SIZE