### PR TITLE
feat(webgl): adapt tanh function in wx miniprogram

### DIFF
--- a/packages/paddlejs-backend-webgl/src/ops/atom/common_func.ts
+++ b/packages/paddlejs-backend-webgl/src/ops/atom/common_func.ts
@@ -66,7 +66,7 @@ const pow_func = `
 
 const tanh_func = `
 float tanh_func(float x, float y, float z) {
-    return tanh(x);
+    return tanh_calc(x);
 }`;
 
 export {

--- a/packages/paddlejs-backend-webgl/src/ops/atom/common_func_adaptor.ts
+++ b/packages/paddlejs-backend-webgl/src/ops/atom/common_func_adaptor.ts
@@ -32,3 +32,19 @@ export function calDivision() {
         `;
 }
 
+export function calTanh() {
+    return `
+    float tanh_calc(float num) {
+        float res = (exp(2.0 * num) - 1.0) / (exp(2.0 * num) + 1.0);
+        return res;
+    }
+    `;
+}
+
+export function adapterFunctions() {
+    return `
+    ${calMod()}
+    ${calDivision()}
+    ${calTanh()}
+    `;
+}

--- a/packages/paddlejs-backend-webgl/src/ops/atom/prefix.ts
+++ b/packages/paddlejs-backend-webgl/src/ops/atom/prefix.ts
@@ -5,7 +5,7 @@
 import { env } from '@paddlejs/paddlejs-core';
 import prefix_uint from './prefix_uint';
 import prefix_half from './prefix_half';
-import { calMod, calDivision } from './common_func_adaptor';
+import { adapterFunctions } from './common_func_adaptor';
 
 function prefixV1() {
     return ` #ifdef GL_FRAGMENT_PRECISION_HIGH
@@ -26,8 +26,7 @@ function prefixV1() {
             int calCeil(int a, int b) {
                 return int(ceil(float(a) / float(b)));
             }
-            ${calMod()}
-            ${calDivision()}
+            ${adapterFunctions()}
     `;
 }
 function prefixV2() {
@@ -52,8 +51,7 @@ function prefixV2() {
         int calCeil(int a, int b) {
             return int(ceil(float(a) / float(b)));
         }
-        ${calMod()}
-        ${calDivision()}
+        ${adapterFunctions()}
     `;
 }
 

--- a/packages/paddlejs-backend-webgl/src/ops/atom/prefix_half.ts
+++ b/packages/paddlejs-backend-webgl/src/ops/atom/prefix_half.ts
@@ -2,7 +2,7 @@
  * @file prefix code of half float type
  */
 
-import { calMod, calDivision } from './common_func_adaptor';
+import { adapterFunctions } from './common_func_adaptor';
 
 export default function () {
     return ` #ifdef GL_FRAGMENT_PRECISION_HIGH
@@ -32,8 +32,7 @@ export default function () {
                 gl_FragColor = result;
             }
 
-            ${calMod()}
-            ${calDivision()}
+            ${adapterFunctions()}
 
             int calCeil(int a, int b) {
                 return int(ceil(float(a) / float(b)));

--- a/packages/paddlejs-backend-webgl/src/ops/atom/prefix_uint.ts
+++ b/packages/paddlejs-backend-webgl/src/ops/atom/prefix_uint.ts
@@ -2,7 +2,7 @@
  * @file prefix code of uint type
  */
 
-import { calMod, calDivision } from './common_func_adaptor';
+import { adapterFunctions } from './common_func_adaptor';
 
 export default function () {
     return `
@@ -20,8 +20,7 @@ export default function () {
             return (val > 0. || val < 1. || val == 0.) ? false : true;
         }
 
-        ${calMod()}
-        ${calDivision()}
+        ${adapterFunctions()}
 
         int calCeil(int a, int b) {
             return int(ceil(float(a) / float(b)));

--- a/packages/paddlejs-backend-webgl/src/ops/shader/rnn/rnn_cell.ts
+++ b/packages/paddlejs-backend-webgl/src/ops/shader/rnn/rnn_cell.ts
@@ -20,7 +20,7 @@ function mainFunc(
         float counter  = getValueFromTensorPos_counter(oPos.r, ${state_axis}, oPos.b, oPos.a);
         float i = 1.0 / (1.0 + exp(-origin));
         float f = 1.0 / (1.0 + exp(-cell));
-        float c = f * counter + i * tanh(appender);
+        float c = f * counter + i * tanh_calc(appender);
         
         setOutput(c);
     }

--- a/packages/paddlejs-backend-webgl/src/ops/shader/rnn/rnn_hidden.ts
+++ b/packages/paddlejs-backend-webgl/src/ops/shader/rnn/rnn_hidden.ts
@@ -21,8 +21,8 @@ function mainFunc(
         float i = 1.0 / (1.0 + exp(-origin));
         float f = 1.0 / (1.0 + exp(-cell));
         float o = 1.0 / (1.0 + exp(-fourth));
-        float c = f * counter + i * tanh(appender);
-        float h = o * tanh(c);
+        float c = f * counter + i * tanh_calc(appender);
+        float h = o * tanh_calc(c);
         
         setOutput(h);
     }


### PR DESCRIPTION
<img width="818" alt="image" src="https://user-images.githubusercontent.com/10822846/155157961-65e50506-8157-4b8b-bb4f-54645bf775b2.png">

微信小程序 glsl compiler 报错，不支持 tanh  
`'tanh' : no matching overloaded function found`