### PR TITLE
add worker compatibility to loader in `paddlejs-core`

### DIFF
--- a/packages/paddlejs-core/src/loader.ts
+++ b/packages/paddlejs-core/src/loader.ts
@@ -154,7 +154,7 @@ export default class ModelLoader {
             ? this.isLocalFile
                 ? this.fetchLocalFile
                 : require('node-fetch')
-            : window.fetch.bind(window);
+            : fetch;
 
         return this.realFetch(path, {
             method: method,


### PR DESCRIPTION
By removing `window` from the client-detected fetch, the `paddlejs-core` lib should now be compatible with worker contexts. Tested in a local context where I use a vendored version of this lib.